### PR TITLE
chore: release v1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Advanced Micro Devices, Inc."]
 license = "MIT"


### PR DESCRIPTION
New release for beacon milestone feature.
Incrementing minor version per https://semver.org/