### PR TITLE
feat: add sshkey pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
Allow beacon to pull a public ssh key from dispatch after boot, and add to authorized_keys file in the test system.
- Corresponding dispatch change: https://github.com/AMDEPYC/dispatch/pull/29
- This change works with versions of dispatch that does not provide any key and does not cause an error.
- For full functionality, the host image needs the openssh-server package.
- This does not do anything with guest images, probably can add a cloudinit script to configure that.

